### PR TITLE
fix missing requirements

### DIFF
--- a/requirments.txt
+++ b/requirments.txt
@@ -5,3 +5,4 @@ huggingface_hub
 hf-transfer
 protobuf
 sentencepiece
+peft


### PR DESCRIPTION
`peft` is missing in the `requirements.txt`, and it is used in `load_downloaded_model.py`.